### PR TITLE
Add role alert to improves accessibility

### DIFF
--- a/lib/generators/alert_message/templates/_alerts.html.erb
+++ b/lib/generators/alert_message/templates/_alerts.html.erb
@@ -4,7 +4,7 @@
 			key = 'notice'
 		end
 	%>
-  <div id="alert" class="alert-message alert-message-<%= key %>">
+  <div id="alert" role="alert" class="alert-message alert-message-<%= key %>">
     <%= value.to_s.html_safe %>
   </div>
 <% end %>

--- a/lib/generators/alert_message/templates/_alerts.html.erb
+++ b/lib/generators/alert_message/templates/_alerts.html.erb
@@ -4,7 +4,7 @@
 			key = 'error'
 		end
 	%>
-    <div class="alert-message alert-message-<%= key %>">
+    <div role="alert" class="alert-message alert-message-<%= key %>">
       <%= value.html_safe %>
     </div>
 <% end %>

--- a/lib/version/version.rb
+++ b/lib/version/version.rb
@@ -1,5 +1,5 @@
 module AlertMessage
   module Version
-    VERSION = '2.0.1'
+    VERSION = '2.0.2'
   end
 end

--- a/lib/version/version.rb
+++ b/lib/version/version.rb
@@ -1,5 +1,5 @@
 module AlertMessage
   module Version
-    VERSION = '1.1.6'
+    VERSION = '1.1.7'
   end
 end


### PR DESCRIPTION
`role=alert` garante o mesmo comportamento de um alert nativo do navegador. por isso, quando uma alert_message for criada na aplicação, a mesma será lida imediatamente pelo leitor de tela por ter o comportamento de um alert :)

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Alert_Role